### PR TITLE
Add lambda info support for defun analysis

### DIFF
--- a/cl-naive-code-analyzer.asd
+++ b/cl-naive-code-analyzer.asd
@@ -3,7 +3,7 @@
   :version "2025.3.3"
   :author ""
   :licence "MIT"
-  :depends-on (eclector eclector-concrete-syntax-tree concrete-syntax-tree trivial-gray-streams cl-naive-store)
+  :depends-on (eclector eclector-concrete-syntax-tree concrete-syntax-tree trivial-gray-streams cl-naive-store alexandria)
   :components ((:file "src/package")
                (:file "src/utils"
                 :depends-on ("src/package"))

--- a/src/cl-naive-code-analyzer.lisp
+++ b/src/cl-naive-code-analyzer.lisp
@@ -206,6 +206,11 @@ result)
        `(:other-options ,(analysis-other-options a)))))
        |#))
 
+(defmethod write-analysis ((a defun-analysis) filename &key)
+  `(,@(call-next-method)
+    ,@(when (analysis-lambda-info a)
+        `(:lambda-info ,(analysis-lambda-info a)))))
+
 #|
 (defmethod write-analysis ((a defclass-analysis) filename &key)
 `(,@(call-next-method a filename)


### PR DESCRIPTION
## Summary
- track lambda-info for defun analyses
- parse lambda lists in defun analyzer
- output lambda-info when writing analysis
- depend on Alexandria for lambda parsing

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6859be4ef5948320922ac50a41016edb