### PR TITLE
Fix duplicate class definition

### DIFF
--- a/src/analyzers.lisp
+++ b/src/analyzers.lisp
@@ -6,6 +6,7 @@
 
 (defclass define-condition-analysis (analysis) ())
 
+
 (defclass defclass-analysis (analysis)
   ((slots :accessor analysis-slots :initform nil)
    (superclasses :accessor analysis-superclasses :initform nil)))
@@ -14,9 +15,6 @@
 
 (defclass defmacro-analysis (analysis) ())
 
-(defclass defclass-analysis (analysis)
-  ((superclasses :accessor analysis-superclasses :initform nil)
-   (slots :accessor analysis-slots :initform nil)))
 
 (defclass deftype-analysis (analysis) ())
 


### PR DESCRIPTION
## Summary
- remove redundant `defclass-analysis` definition

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6859be13ae1c832092dfd59ea4e0c1a3