### PR TITLE
Move docstring and parameter slots to specialized analyses

### DIFF
--- a/src/analyzers.lisp
+++ b/src/analyzers.lisp
@@ -1,30 +1,46 @@
 (in-package :cl-naive-code-analyzer)
 
 (defclass defun-analysis (analysis)
-  ((lambda-info :accessor analysis-lambda-info :initform nil)))
+  ((lambda-info :accessor analysis-lambda-info :initform nil)
+   (parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
-(defclass defmethod-analysis (analysis) ())
+(defclass defmethod-analysis (analysis)
+  ((parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
-(defclass define-condition-analysis (analysis) ())
+(defclass define-condition-analysis (analysis)
+  ((docstring :accessor analysis-docstring :initform nil)))
 
 
 (defclass defclass-analysis (analysis)
   ((slots :accessor analysis-slots :initform nil)
-   (superclasses :accessor analysis-superclasses :initform nil)))
+   (superclasses :accessor analysis-superclasses :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
-(defclass defparameter-analysis (analysis) ())
+(defclass defparameter-analysis (analysis)
+  ((docstring :accessor analysis-docstring :initform nil)))
 
-(defclass defmacro-analysis (analysis) ())
+(defclass defmacro-analysis (analysis)
+  ((parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
 
-(defclass deftype-analysis (analysis) ())
+(defclass deftype-analysis (analysis)
+  ((parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
-(defclass defgeneric-analysis (analysis) ())
+(defclass defgeneric-analysis (analysis)
+  ((parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
 (defclass defstruct-analysis (analysis)
-  ((slots :accessor analysis-slots :initform nil)))
+  ((slots :accessor analysis-slots :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
-(defclass defsetf-analysis (analysis) ())
+(defclass defsetf-analysis (analysis)
+  ((parameters :accessor analysis-parameters :initform nil)
+   (docstring :accessor analysis-docstring :initform nil)))
 
 (defclass define-symbol-macro-analysis (analysis) ())
 


### PR DESCRIPTION
## Summary
- remove `docstring` and `parameters` slots from the base `analysis` class
- add the two slots to `defun-analysis` and other analysis subclasses that support them
- update `write-analysis` to only include the fields for relevant classes
- clean up `write-analysis` by creating specialized methods per analysis type

## Testing
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_6859c99a94608320a5c9377cd3ea9d6d